### PR TITLE
Add Docker build script

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,5 +22,10 @@ Consulte a documentação do projeto para preparar o ambiente e então executar:
 buildozer android debug
 ```
 
+Ou utilize o script `./build_android_docker.sh` para compilar em um container Docker:
+```
+./build_android_docker.sh
+```
+
 Use as setas do teclado ou toques (deslizes) para mover sua cobra. A pontuação exibida no topo indica quantas comidas cada cobra coletou. Na tela
 inicial também é possível selecionar a dificuldade tocando nos botões ou pressionando as teclas **1**, **2** ou **3**.

--- a/build_android_docker.sh
+++ b/build_android_docker.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# Compila o Snake Game para Android usando Docker e Buildozer
+
+set -euo pipefail
+
+IMAGE="kivy/buildozer:latest"
+
+# Executa o build dentro do container Buildozer
+# Monta o diretório do projeto em /home/user/app
+
+docker run --rm -v "$(pwd)":/home/user/app -w /home/user/app "$IMAGE" \
+    buildozer android debug

--- a/buildozer.spec
+++ b/buildozer.spec
@@ -1,0 +1,15 @@
+[app]
+title = Snake Game
+package.name = snakegame
+package.domain = org.example
+source.dir = .
+source.include_exts = py,png,jpg,kv,atlas
+version = 0.1
+requirements = python3,kivy
+entrypoint = kivy_main.py
+orientation = landscape
+fullscreen = 1
+
+[buildozer]
+log_level = 2
+warn_on_root = 1


### PR DESCRIPTION
## Summary
- add a buildozer spec file
- add a Docker-based build script for Android
- document new build script in README

## Testing
- `python -m py_compile main.py kivy_main.py`

------
https://chatgpt.com/codex/tasks/task_e_68462e32d62c8324ae377c66fd0883ad